### PR TITLE
fix: change loa representation from string to int

### DIFF
--- a/indykite/resource_authorization_policy.go
+++ b/indykite/resource_authorization_policy.go
@@ -77,7 +77,7 @@ func resourceAuthorizationPolicyFlatten(
 		return append(d, buildPluginError("config in the response is not valid AuthorizationPolicyConfig"))
 	}
 
-	jsonVal, err := protojson.MarshalOptions{EmitUnpopulated: true}.Marshal(clientConf)
+	jsonVal, err := protojson.MarshalOptions{EmitUnpopulated: true, UseEnumNumbers: true}.Marshal(clientConf)
 	if err != nil {
 		return append(d, buildPluginError("failed to marshall message into JSON: "+err.Error()))
 	}

--- a/indykite/resource_authorization_policy_test.go
+++ b/indykite/resource_authorization_policy_test.go
@@ -411,7 +411,7 @@ var _ = Describe("Resource Authorization Policy config", func() {
 										"identityProperties":[{
 											"property": "email",
 											"value": "wonka@indykite.com",
-											"minimumAssuranceLevel": "ASSURANCE_LEVEL_LOW",
+											"minimumAssuranceLevel": 1,
 											"allowedIssuers": ["google.com"],
 											"allowedVerifiers": ["google.com"],
 											"mustBePrimary": true,
@@ -460,7 +460,7 @@ func testAuthorizationPolicyResourceDataExists(
 		}
 		attrs := rs.Primary.Attributes
 
-		expectedJSON, err := protojson.MarshalOptions{EmitUnpopulated: true}.
+		expectedJSON, err := protojson.MarshalOptions{EmitUnpopulated: true, UseEnumNumbers: true}.
 			Marshal(data.ConfigNode.GetAuthorizationPolicyConfig())
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/indykite/.github/blob/master/commit-message.md)
- [ ] is breaking change

## Description of change

When creating polices with identity property minimumAssuranceLevel, the value provided is an integer; 1.
When reading back the created policy, the value is presented as string; ASSURANCE_LEVEL_LOW

Both string and int are acceptable in create/update date payload, but we should however change this so that only integer is returned.

Link to issue: https://app.zenhub.com/workspaces/authorization-634ef6a7311efd002317f7bc/issues/indykite/jarvis-backlog/2904
