### PR TITLE
ci: add tfplugindocs to GitHub Actions

### DIFF
--- a/.github/workflows/tfplugindocs.yaml
+++ b/.github/workflows/tfplugindocs.yaml
@@ -1,0 +1,41 @@
+---
+name: Terraform plugin docs
+concurrency: tfplugindocs
+on:
+    push:
+        branches:
+            - master
+
+permissions:
+    contents: write
+
+jobs:
+    tfplugindocs:
+        name: Generate Terraform plugin docs
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+
+            - name: Set up Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version-file: go.mod
+
+            - name: Generate docs
+              run: |
+                  make install-tools tfdocs_generate
+
+            - name: Fix trailing whitespace & EOF in generated docs
+              uses: pre-commit/action@v3.0.0
+              # ignoring errors, as pre-commit will fail if files were modified
+              continue-on-error: true
+              with:
+                  extra_args: --hook-stage=manual --all-files
+
+            - name: Commit generated docs
+              uses: stefanzweifel/git-auto-commit-action@v4
+              with:
+                  # using ci: prefix to hide this commit from changelog
+                  commit_message: 'ci: update Terraform plugin docs'
+                  commit_options: --no-verify --signoff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,9 @@ repos:
       rev: v4.4.0
       hooks:
           - id: trailing-whitespace
+            stages: [commit, push, manual]
           - id: end-of-file-fixer
+            stages: [commit, push, manual]
           - id: check-yaml
           - id: check-toml
           - id: check-merge-conflict

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ download:
 
 install-tools: download
 	@echo Installing tools from tools.go
-	@go install $$(go list -f '{{range .Imports}}{{.}} {{end}}' tools.go)
+	@go install $$(go list -e -f '{{range .Imports}}{{.}} {{end}}' tools.go)
 
 test:
 	go test -v -cpu 4 -covermode=count -coverpkg github.com/indykite/terraform-provider-indykite/... -coverprofile=coverage.out ./...


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/indykite/.github/blob/master/commit-message.md)
- [ ] is breaking change

## Description of change

Add tfplugindocs to GitHub Actions.

Details & side-effects:
- Documentation is generated using `tfplugindocs`
- After that, **all files** (i.e. not only `docs/*` are modified using `pre-commit` hooks: `trailing-whitespace`, `end-of-file-fixer`
- As `pre-commit` fails if any files are modified, failures in these workflow steps are ignored. It means that also any other failures related to `pre-commit` (installation, any issues while running hooks) will be silently ignored. Details would still be in workflow run logs
- At the end, if any files were changed (added, modified or deleted), they will get committed with message `ci: update Terraform plugin docs` to avoid from appearing in `CHANGELOG.md`
- Commit will be unverified on GitHun
- Commits will happen without personal access token, which means that any other workflows will not get triggered. This is also to avoid potential (albeit rare) situation of endless loop
- As a side effect, `release-please` workflow won't be triggered automatically

In order to de-clutter this repo, I performed my tests on https://github.com/indykite/test-terraform-provider