### PR TITLE
fix: fix read app_space data source by name

### DIFF
--- a/indykite/data_source_application_space.go
+++ b/indykite/data_source_application_space.go
@@ -16,7 +16,6 @@ package indykite
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -79,38 +78,6 @@ func dataSourceAppSpaceList() *schema.Resource {
 	}
 }
 
-// lookupApplicationSpaceByName finds an application space by name within a customer.
-func lookupApplicationSpaceByName(
-	ctx context.Context,
-	clientCtx *ClientContext,
-	data *schema.ResourceData,
-	name string,
-) (*ApplicationSpaceResponse, diag.Diagnostic) {
-	customerID := data.Get(customerIDKey).(string)
-	var listResp ListApplicationSpacesResponse
-	err := clientCtx.GetClient().Get(ctx, "/projects?organization_id="+customerID, &listResp)
-	if err != nil {
-		return nil, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  fmt.Sprintf("failed to list application spaces: %v", err),
-		}
-	}
-
-	// Find app space by name
-	for i := range listResp.AppSpaces {
-		if listResp.AppSpaces[i].Name == name {
-			return &listResp.AppSpaces[i], diag.Diagnostic{}
-		}
-	}
-
-	return nil, diag.Diagnostic{
-		Severity: diag.Error,
-		Summary: fmt.Sprintf(
-			"application space with name '%s' not found in customer '%s'",
-			name, customerID),
-	}
-}
-
 func dataAppSpaceReadContext(ctx context.Context, data *schema.ResourceData, meta any) diag.Diagnostics {
 	var d diag.Diagnostics
 	clientCtx := getClientContext(&d, meta)
@@ -130,17 +97,13 @@ func dataAppSpaceReadContext(ctx context.Context, data *schema.ResourceData, met
 		resp = &ApplicationSpaceResponse{}
 		err = clientCtx.GetClient().Get(ctx, "/projects/"+id.(string), resp)
 	} else if name, exists := data.GetOk(nameKey); exists {
-		// Look up by name within customer
-		var diagErr diag.Diagnostic
-		resp, diagErr = lookupApplicationSpaceByName(ctx, clientCtx, data, name.(string))
-		// Only return if there's an actual error (non-zero severity with summary)
-		if diagErr.Summary != "" {
-			return append(d, diagErr)
-		}
+		// Direct lookup by name (API accepts name as the {id} path parameter)
+		resp = &ApplicationSpaceResponse{}
+		err = clientCtx.GetClient().Get(ctx, "/projects/"+name.(string), resp)
 	}
 
-	if readHasFailed(&d, err, data) {
-		return d
+	if err != nil {
+		return append(d, buildPluginError(err.Error()))
 	}
 
 	return dataAppSpaceFlatten(data, resp)

--- a/indykite/data_source_application_space_test.go
+++ b/indykite/data_source_application_space_test.go
@@ -82,26 +82,19 @@ var _ = Describe("DataSource Application Space", func() {
 
 		mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
-			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/projects") &&
-				r.URL.Query().Get("organization_id") == customerID:
-				// List application spaces by customer
-				w.WriteHeader(http.StatusOK)
-				if nameFound {
-					// Return the app space for successful name lookup
-					_ = json.NewEncoder(w).Encode(indykite.ListApplicationSpacesResponse{
-						AppSpaces: []indykite.ApplicationSpaceResponse{appSpaceResp},
-					})
-				} else {
-					// Return empty list (name not found)
-					_ = json.NewEncoder(w).Encode(indykite.ListApplicationSpacesResponse{
-						AppSpaces: []indykite.ApplicationSpaceResponse{},
-					})
-				}
 			case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/projects/"+appSpaceID):
 				// Read by ID - this also triggers nameFound for next test
 				nameFound = true
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode(appSpaceResp)
+			case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/projects/acme"):
+				// Read by name
+				if nameFound {
+					w.WriteHeader(http.StatusOK)
+					_ = json.NewEncoder(w).Encode(appSpaceResp)
+				} else {
+					w.WriteHeader(http.StatusNotFound)
+				}
 			default:
 				w.WriteHeader(http.StatusNotFound)
 			}
@@ -144,7 +137,7 @@ var _ = Describe("DataSource Application Space", func() {
 						customer_id = "` + customerID + `"
 						name = "acme"
 					}`,
-					ExpectError: regexp.MustCompile("application space with name 'acme' not found"),
+					ExpectError: regexp.MustCompile("HTTP 404"),
 				},
 
 				// Success test cases

--- a/tests/provider/test.tf
+++ b/tests/provider/test.tf
@@ -566,6 +566,13 @@ data "indykite_application_space" "lookup_appspace" {
   depends_on   = [indykite_application_space.appspace]
 }
 
+# Look up the application space by name
+data "indykite_application_space" "lookup_appspace_by_name" {
+  customer_id = data.indykite_customer.customer.id
+  name        = local.app_space_name
+  depends_on  = [indykite_application_space.appspace]
+}
+
 # Look up the application we created
 data "indykite_application" "lookup_application" {
   application_id = indykite_application.application.id


### PR DESCRIPTION
implement [ENG-8462]

fix read app_space data source by name:

-  data_source_application_space.go:                                                                                                                                    
  1. Removed lookupApplicationSpaceByName function (list-then-filter approach)                                                                                         
  2. Changed name-based lookup to use GET /projects/<name> directly (matching the API spec where {id} accepts "Project ID or name")                                    
  3. Changed error handling from HasFailed to direct err != nil check :  data sources should treat 404 as a hard error, not a warning                                   
  4. Removed unused fmt import                                                                                                                                         
                                                                                                                                                                       
 - data_source_application_space_test.go:                                                                                                                               
  1. Updated mock to handle GET /projects/acme (read by name) instead of list endpoint                                                                                 
  2. Updated error expectation from custom message to HTTP 404    

- test.tf: add integration test

[ENG-8462]: https://indykite.atlassian.net/browse/ENG-8462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ