### PR TITLE
fix: fix update validations and add tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,6 +30,7 @@ test:
 integration:
 	cd ./tests/provider && terraform plan && terraform apply -input=false -auto-approve
 	cd ./tests/terraform && go test --tags=integration ./...
+	cd ./tests/provider && cp test.tf test.tf.bak && sed -i 's/description\(\s*=\s*"\)/description\1Updated - /g' test.tf && terraform apply -input=false -auto-approve; mv test.tf.bak test.tf
 	cd ./tests/provider && terraform destroy -input=false -auto-approve && rm terraform.tfstate terraform.tfstate.backup
 
 upgrade_test_provider:

--- a/indykite/resource_authorization_policy.go
+++ b/indykite/resource_authorization_policy.go
@@ -172,20 +172,15 @@ func resAuthorizationPolicyUpdate(ctx context.Context, data *schema.ResourceData
 	ctx, cancel := context.WithTimeout(ctx, data.Timeout(schema.TimeoutUpdate))
 	defer cancel()
 
+	policy := data.Get(authzJSONConfigKey).(string)
+	statusValue := data.Get(authzStatusKey).(string)
+	apiStatus := AuthorizationPolicyStatusToAPI[statusValue]
+
 	req := UpdateAuthorizationPolicyRequest{
 		DisplayName: updateOptionalString(data, displayNameKey),
 		Description: updateOptionalString(data, descriptionKey),
-	}
-
-	if data.HasChange(authzJSONConfigKey) {
-		policy := data.Get(authzJSONConfigKey).(string)
-		req.Policy = &policy
-	}
-
-	if data.HasChange(authzStatusKey) {
-		statusValue := data.Get(authzStatusKey).(string)
-		apiStatus := AuthorizationPolicyStatusToAPI[statusValue]
-		req.Status = &apiStatus
+		Policy:      &policy,
+		Status:      &apiStatus,
 	}
 
 	if data.HasChange(authzTagsKey) {

--- a/indykite/resource_authorization_policy_test.go
+++ b/indykite/resource_authorization_policy_test.go
@@ -67,6 +67,30 @@ var _ = Describe("Resource Authorization Policy config", func() {
 		mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/authorization-policies"):
+				var reqBody map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]string{"message": "invalid request body"})
+					return
+				}
+
+				// Validate that policy and status are present
+				var errs []string
+				if _, ok := reqBody["policy"]; !ok {
+					errs = append(errs, "missing field policy")
+				}
+				if _, ok := reqBody["status"]; !ok {
+					errs = append(errs, "missing field status")
+				}
+				if len(errs) > 0 {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"message": "Unprocessable Entity",
+						"errors":  errs,
+					})
+					return
+				}
+
 				resp := indykite.AuthorizationPolicyResponse{
 					ID:          sampleID,
 					Name:        "wonka-authorization-policy-config",
@@ -115,6 +139,30 @@ var _ = Describe("Resource Authorization Policy config", func() {
 				_ = json.NewEncoder(w).Encode(resp)
 
 			case r.Method == http.MethodPut && strings.Contains(r.URL.Path, sampleID):
+				var reqBody map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]string{"message": "invalid request body"})
+					return
+				}
+
+				// Validate that policy and status are always present in PUT requests
+				var errs []string
+				if _, ok := reqBody["policy"]; !ok {
+					errs = append(errs, "missing field policy")
+				}
+				if _, ok := reqBody["status"]; !ok {
+					errs = append(errs, "missing field status")
+				}
+				if len(errs) > 0 {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"message": "Unprocessable Entity",
+						"errors":  errs,
+					})
+					return
+				}
+
 				updated = true
 				resp := indykite.AuthorizationPolicyResponse{
 					ID:          sampleID,
@@ -388,6 +436,30 @@ var _ = Describe("Resource Authorization Policy Import by Name", func() {
 		mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/authorization-policies"):
+				var reqBody map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]string{"message": "invalid request body"})
+					return
+				}
+
+				// Validate that policy and status are present
+				var errs []string
+				if _, ok := reqBody["policy"]; !ok {
+					errs = append(errs, "missing field policy")
+				}
+				if _, ok := reqBody["status"]; !ok {
+					errs = append(errs, "missing field status")
+				}
+				if len(errs) > 0 {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"message": "Unprocessable Entity",
+						"errors":  errs,
+					})
+					return
+				}
+
 				resp := indykite.AuthorizationPolicyResponse{
 					ID:          policyID,
 					CustomerID:  customerID,

--- a/indykite/resource_entity_matching_pipeline.go
+++ b/indykite/resource_entity_matching_pipeline.go
@@ -185,13 +185,9 @@ func resEntityMatchingPipelineUpdate(ctx context.Context, data *schema.ResourceD
 	defer cancel()
 
 	req := UpdateEntityMatchingPipelineRequest{
-		DisplayName: updateOptionalString(data, displayNameKey),
-		Description: updateOptionalString(data, descriptionKey),
-	}
-
-	if data.HasChange(entityMatchingPipelineSimilarityScoreCutOffKey) {
-		score := float32(data.Get(entityMatchingPipelineSimilarityScoreCutOffKey).(float64))
-		req.SimilarityScoreCutoff = &score
+		DisplayName:           updateOptionalString(data, displayNameKey),
+		Description:           updateOptionalString(data, descriptionKey),
+		SimilarityScoreCutoff: float32(data.Get(entityMatchingPipelineSimilarityScoreCutOffKey).(float64)),
 	}
 
 	if data.HasChange(entityMatchingPipelineRerunInterval) {

--- a/indykite/resource_event_sink.go
+++ b/indykite/resource_event_sink.go
@@ -435,10 +435,7 @@ func resEventSinkUpdate(ctx context.Context, data *schema.ResourceData, meta any
 	req := UpdateEventSinkRequest{
 		DisplayName: updateOptionalString(data, displayNameKey),
 		Description: updateOptionalString(data, descriptionKey),
-	}
-
-	if data.HasChange(providersKey) || data.HasChange(routesKey) {
-		req.Config = buildEventSinkConfig(data)
+		Config:      buildEventSinkConfig(data),
 	}
 
 	var resp EventSinkResponse

--- a/indykite/resource_external_data_resolver.go
+++ b/indykite/resource_external_data_resolver.go
@@ -258,42 +258,22 @@ func resExternalDataResolverUpdate(ctx context.Context, data *schema.ResourceDat
 	defer cancel()
 
 	req := UpdateExternalDataResolverRequest{
-		DisplayName: updateOptionalString(data, displayNameKey),
-		Description: updateOptionalString(data, descriptionKey),
-	}
-
-	if data.HasChange(externalDataResolverURLKey) {
-		url := data.Get(externalDataResolverURLKey).(string)
-		req.URL = &url
-	}
-
-	if data.HasChange(externalDataResolverMethodKey) {
-		method := data.Get(externalDataResolverMethodKey).(string)
-		req.Method = &method
+		DisplayName:      updateOptionalString(data, displayNameKey),
+		Description:      updateOptionalString(data, descriptionKey),
+		URL:              data.Get(externalDataResolverURLKey).(string),
+		Method:           data.Get(externalDataResolverMethodKey).(string),
+		RequestType:      strings.ToUpper(data.Get(externalDataResolverRequestTypeKey).(string)),
+		ResponseType:     strings.ToUpper(data.Get(externalDataResolverResponseTypeKey).(string)),
+		ResponseSelector: data.Get(externalDataResolverResponseSelectorKey).(string),
 	}
 
 	if data.HasChange(externalDataResolverHeadersKey) {
 		req.Headers = buildHeaders(data)
 	}
 
-	if data.HasChange(externalDataResolverRequestTypeKey) {
-		requestType := strings.ToUpper(data.Get(externalDataResolverRequestTypeKey).(string))
-		req.RequestType = &requestType
-	}
-
 	if data.HasChange(externalDataResolverRequestPayloadKey) {
 		requestPayload := data.Get(externalDataResolverRequestPayloadKey).(string)
 		req.RequestPayload = &requestPayload
-	}
-
-	if data.HasChange(externalDataResolverResponseTypeKey) {
-		responseType := strings.ToUpper(data.Get(externalDataResolverResponseTypeKey).(string))
-		req.ResponseType = &responseType
-	}
-
-	if data.HasChange(externalDataResolverResponseSelectorKey) {
-		responseSelector := data.Get(externalDataResolverResponseSelectorKey).(string)
-		req.ResponseSelector = &responseSelector
 	}
 
 	var resp ExternalDataResolverResponse

--- a/indykite/resource_ingest_pipeline.go
+++ b/indykite/resource_ingest_pipeline.go
@@ -166,17 +166,10 @@ func resIngestPipelineUpdate(ctx context.Context, data *schema.ResourceData, met
 	defer cancel()
 
 	req := UpdateIngestPipelineRequest{
-		DisplayName: updateOptionalString(data, displayNameKey),
-		Description: updateOptionalString(data, descriptionKey),
-	}
-
-	if data.HasChange(ingestPipelineSourcesTypeKey) {
-		req.Sources = rawArrayToTypedArray[string](data.Get(ingestPipelineSourcesTypeKey).([]any))
-	}
-
-	if data.HasChange(ingestPipelineAppAgentTokenTypeKey) {
-		appAgentToken := data.Get(ingestPipelineAppAgentTokenTypeKey).(string)
-		req.AppAgentToken = &appAgentToken
+		DisplayName:   updateOptionalString(data, displayNameKey),
+		Description:   updateOptionalString(data, descriptionKey),
+		Sources:       rawArrayToTypedArray[string](data.Get(ingestPipelineSourcesTypeKey).([]any)),
+		AppAgentToken: data.Get(ingestPipelineAppAgentTokenTypeKey).(string),
 	}
 
 	var resp IngestPipelineResponse

--- a/indykite/resource_knowledge_query.go
+++ b/indykite/resource_knowledge_query.go
@@ -187,22 +187,9 @@ func resKnowledgeQueryUpdate(ctx context.Context, data *schema.ResourceData, met
 	req := UpdateKnowledgeQueryRequest{
 		DisplayName: updateOptionalString(data, displayNameKey),
 		Description: updateOptionalString(data, descriptionKey),
-	}
-
-	if data.HasChange(knowledgeQueryJSONQueryConfigKey) {
-		query := data.Get(knowledgeQueryJSONQueryConfigKey).(string)
-		req.Query = &query
-	}
-
-	if data.HasChange(knowledgeQueryStatusKey) {
-		statusValue := data.Get(knowledgeQueryStatusKey).(string)
-		apiStatus := KnowledgeQueryStatusToAPI[statusValue]
-		req.Status = &apiStatus
-	}
-
-	if data.HasChange(knowledgeQueryPolicyID) {
-		policyID := data.Get(knowledgeQueryPolicyID).(string)
-		req.PolicyID = &policyID
+		Query:       data.Get(knowledgeQueryJSONQueryConfigKey).(string),
+		Status:      KnowledgeQueryStatusToAPI[data.Get(knowledgeQueryStatusKey).(string)],
+		PolicyID:    data.Get(knowledgeQueryPolicyID).(string),
 	}
 
 	var resp KnowledgeQueryResponse

--- a/indykite/resource_token_introspect.go
+++ b/indykite/resource_token_introspect.go
@@ -327,11 +327,13 @@ func resTokenIntrospectUpdate(ctx context.Context, data *schema.ResourceData, me
 		Description: updateOptionalString(data, descriptionKey),
 	}
 
+	req.IKGNodeType = data.Get(tokenIntrospectIKGNodeTypeKey).(string)
+	req.PerformUpsert = data.Get(tokenIntrospectPerformUpsertKey).(bool)
+
 	// Add changed fields
 	if data.HasChange(tokenIntrospectJWTKey) || data.HasChange(tokenIntrospectOpaqueKey) ||
 		data.HasChange(tokenIntrospectOfflineKey) || data.HasChange(tokenIntrospectOnlineKey) ||
-		data.HasChange(tokenIntrospectClaimsMappingKey) || data.HasChange(tokenIntrospectSubClaimKey) ||
-		data.HasChange(tokenIntrospectIKGNodeTypeKey) || data.HasChange(tokenIntrospectPerformUpsertKey) {
+		data.HasChange(tokenIntrospectClaimsMappingKey) || data.HasChange(tokenIntrospectSubClaimKey) {
 		tokenReq := buildTokenIntrospectRequest(data)
 		req.JWT = tokenReq.JWT
 		req.Opaque = tokenReq.Opaque
@@ -339,15 +341,6 @@ func resTokenIntrospectUpdate(ctx context.Context, data *schema.ResourceData, me
 		req.Online = tokenReq.Online
 		req.ClaimsMapping = tokenReq.ClaimsMapping
 		req.SubClaim = tokenReq.SubClaim
-
-		if data.HasChange(tokenIntrospectIKGNodeTypeKey) {
-			nodeType := data.Get(tokenIntrospectIKGNodeTypeKey).(string)
-			req.IKGNodeType = &nodeType
-		}
-		if data.HasChange(tokenIntrospectPerformUpsertKey) {
-			performUpsert := data.Get(tokenIntrospectPerformUpsertKey).(bool)
-			req.PerformUpsert = &performUpsert
-		}
 	}
 
 	var resp TokenIntrospectResponse

--- a/indykite/resource_trust_score_profile.go
+++ b/indykite/resource_trust_score_profile.go
@@ -217,19 +217,14 @@ func resTrustScoreProfileUpdate(ctx context.Context, data *schema.ResourceData, 
 	ctx, cancel := context.WithTimeout(ctx, data.Timeout(schema.TimeoutUpdate))
 	defer cancel()
 
+	scheduleValue := data.Get(trustScoreProfileSchedule).(string)
+	apiSchedule := TrustScoreProfileScheduleToAPI[scheduleValue]
+
 	req := UpdateTrustScoreProfileRequest{
 		DisplayName: updateOptionalString(data, displayNameKey),
 		Description: updateOptionalString(data, descriptionKey),
-	}
-
-	if data.HasChange(trustScoreProfileDimensionsKey) {
-		req.Dimensions = buildDimensions(data)
-	}
-
-	if data.HasChange(trustScoreProfileSchedule) {
-		scheduleValue := data.Get(trustScoreProfileSchedule).(string)
-		apiSchedule := TrustScoreProfileScheduleToAPI[scheduleValue]
-		req.Schedule = &apiSchedule
+		Dimensions:  buildDimensions(data),
+		Schedule:    apiSchedule,
 	}
 
 	var resp TrustScoreProfileResponse

--- a/indykite/rest_models.go
+++ b/indykite/rest_models.go
@@ -303,8 +303,8 @@ type UpdateTokenIntrospectRequest struct {
 	Online        *TokenIntrospectOnline           `json:"online,omitempty"`
 	ClaimsMapping map[string]*TokenIntrospectClaim `json:"claims_mapping,omitempty"`
 	SubClaim      *TokenIntrospectClaim            `json:"sub_claim,omitempty"`
-	IKGNodeType   *string                          `json:"ikg_node_type,omitempty"`
-	PerformUpsert *bool                            `json:"perform_upsert,omitempty"`
+	IKGNodeType   string                           `json:"ikg_node_type"`
+	PerformUpsert bool                             `json:"perform_upsert"`
 }
 
 // Ingest Pipeline structures
@@ -337,8 +337,8 @@ type IngestPipelineResponse struct {
 type UpdateIngestPipelineRequest struct {
 	DisplayName   *string  `json:"display_name,omitempty"`
 	Description   *string  `json:"description,omitempty"`
-	AppAgentToken *string  `json:"app_agent_token,omitempty"`
-	Sources       []string `json:"sources,omitempty"`
+	AppAgentToken string   `json:"app_agent_token"`
+	Sources       []string `json:"sources"`
 }
 
 // External Data Resolver structures
@@ -388,13 +388,13 @@ type ExternalDataResolverResponse struct {
 type UpdateExternalDataResolverRequest struct {
 	DisplayName      *string        `json:"display_name,omitempty"`
 	Description      *string        `json:"description,omitempty"`
-	URL              *string        `json:"url,omitempty"`
-	Method           *string        `json:"method,omitempty"`
+	URL              string         `json:"url"`
+	Method           string         `json:"method"`
 	Headers          map[string]any `json:"headers,omitempty"`
-	RequestType      *string        `json:"request_content_type,omitempty"`
+	RequestType      string         `json:"request_content_type"`
 	RequestPayload   *string        `json:"request_payload,omitempty"`
-	ResponseType     *string        `json:"response_content_type,omitempty"`
-	ResponseSelector *string        `json:"response_selector,omitempty"`
+	ResponseType     string         `json:"response_content_type"`
+	ResponseSelector string         `json:"response_selector"`
 }
 
 // Entity Matching Pipeline structures
@@ -434,10 +434,10 @@ type EntityMatchingPipelineResponse struct {
 
 // UpdateEntityMatchingPipelineRequest represents the request to update an entity matching pipeline.
 type UpdateEntityMatchingPipelineRequest struct {
-	DisplayName           *string  `json:"display_name,omitempty"`
-	Description           *string  `json:"description,omitempty"`
-	SimilarityScoreCutoff *float32 `json:"similarity_score_cutoff,omitempty"`
-	RerunInterval         *string  `json:"rerun_interval,omitempty"`
+	DisplayName           *string `json:"display_name,omitempty"`
+	Description           *string `json:"description,omitempty"`
+	RerunInterval         *string `json:"rerun_interval,omitempty"`
+	SimilarityScoreCutoff float32 `json:"similarity_score_cutoff"`
 }
 
 // Knowledge Query structures
@@ -473,9 +473,9 @@ type KnowledgeQueryResponse struct {
 type UpdateKnowledgeQueryRequest struct {
 	DisplayName *string `json:"display_name,omitempty"`
 	Description *string `json:"description,omitempty"`
-	Query       *string `json:"query,omitempty"`
-	Status      *string `json:"status,omitempty"`
-	PolicyID    *string `json:"policy_id,omitempty"`
+	Query       string  `json:"query"`
+	Status      string  `json:"status"`
+	PolicyID    string  `json:"policy_id"`
 }
 
 // Trust Score Profile structures
@@ -517,8 +517,8 @@ type TrustScoreProfileResponse struct {
 type UpdateTrustScoreProfileRequest struct {
 	DisplayName *string                `json:"display_name,omitempty"`
 	Description *string                `json:"description,omitempty"`
-	Schedule    *string                `json:"schedule,omitempty"`
-	Dimensions  []*TrustScoreDimension `json:"dimensions,omitempty"`
+	Schedule    string                 `json:"schedule"`
+	Dimensions  []*TrustScoreDimension `json:"dimensions"`
 }
 
 // Config Node structures (generic for multiple resource types)
@@ -601,7 +601,7 @@ type EventSinkResponse struct {
 type UpdateEventSinkRequest struct {
 	DisplayName *string        `json:"display_name,omitempty"`
 	Description *string        `json:"description,omitempty"`
-	Config      map[string]any `json:"config,omitempty"`
+	Config      map[string]any `json:"config"`
 }
 
 // Service Account structures


### PR DESCRIPTION
implement [ENG-8462]

1. rest_models.go — Struct field type changes                                                                                                                        
   Ensure the fields are always serialized in the JSON request body, even when set to zero values.                                                                                                                               
                                                                                                                                                                       
  2. Resource update functions — Always send required fields                                                                                                                                                              
  In each resource's update function, the data.HasChange(...) conditionals were removed for required fields. 
                                                                                                                                                                       
  3. Tests — Validation added to mock server                                                                                                                                                            
  The authorization policy test mock server now validates that policy and status fields are present in both POST (create) and PUT (update) requests, returning 422 if missing.                                                                                                                                                             
                                                                                                                                                                       
  4. Integration test update
  - GNUmakefile — Added a step to apply modifications on test.tf during integration tests 

[ENG-8462]: https://indykite.atlassian.net/browse/ENG-8462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ