### PR TITLE
fix: wait until app agent is available

### DIFF
--- a/indykite/export_test.go
+++ b/indykite/export_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 IndyKite
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indykite
+
+import "time"
+
+// SetCredCreateRetryDelay overrides the application agent credential create retry
+// delay for tests and returns a function that restores the original value. This
+// keeps tests that exercise the propagation retry fast.
+func SetCredCreateRetryDelay(d time.Duration) func() {
+	orig := credCreateRetryDelay
+	credCreateRetryDelay = d
+	return func() { credCreateRetryDelay = orig }
+}
+
+// CredCreateMaxRetries exposes the credential create retry bound to tests.
+func CredCreateMaxRetries() int {
+	return credCreateMaxRetries
+}

--- a/indykite/resource_application_agent_credential.go
+++ b/indykite/resource_application_agent_credential.go
@@ -34,6 +34,16 @@ const (
 	agentConfigKey  = "agent_config"
 )
 
+// A freshly created application agent may not be immediately visible to the
+// credential endpoint. When a credential is created in the same apply as its
+// agent, retry the create on a not-found response to ride out that propagation
+// delay instead of failing the apply.
+const credCreateMaxRetries = 5
+
+// credCreateRetryDelay is a var (not const) so tests can shorten it via the seam
+// in export_test.go instead of waiting the full production delay.
+var credCreateRetryDelay = 2 * time.Second
+
 func resourceApplicationAgentCredential() *schema.Resource {
 	return &schema.Resource{
 		Description:   "App agent credentials is a JSON configuration file that contains a secret key or token. ",
@@ -89,16 +99,40 @@ func resourceApplicationAgentCredential() *schema.Resource {
 				Description:      "Provide your onw Public key in JWK format, otherwise new pair is generated",
 			},
 			expireTimeKey: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsRFC3339Time,
-				Description:  "Optional date-time when credentials are going to expire",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateFunc:     validation.IsRFC3339Time,
+				DiffSuppressFunc: ExpireTimeDiffSuppress,
+				Description:      "Optional date-time when credentials are going to expire",
 			},
 			kidKey:         {Type: schema.TypeString, Computed: true},
 			agentConfigKey: {Type: schema.TypeString, Computed: true, Sensitive: true},
 			createTimeKey:  createTimeSchema(),
 		},
+	}
+}
+
+// postAppAgentCredentialWithRetry issues the credential create request, retrying on
+// not-found responses to ride out the delay before a freshly created application
+// agent becomes visible to the credential endpoint. The final (possibly not-found)
+// error is returned for the caller to classify.
+func postAppAgentCredentialWithRetry(
+	ctx context.Context,
+	client *RestClient,
+	req *CreateApplicationAgentCredentialRequest,
+) (ApplicationAgentCredentialResponse, error) {
+	var resp ApplicationAgentCredentialResponse
+	for attempt := 0; ; attempt++ {
+		err := client.Post(ctx, "/application-agent-credentials", req, &resp)
+		if err == nil || !IsNotFoundError(err) || attempt >= credCreateMaxRetries {
+			return resp, err
+		}
+		select {
+		case <-time.After(credCreateRetryDelay):
+		case <-ctx.Done():
+			return resp, ctx.Err()
+		}
 	}
 }
 
@@ -130,8 +164,16 @@ func resAppAgentCredCreate(ctx context.Context, data *schema.ResourceData, meta 
 		req.PublicKeyJWK = strings.TrimSpace(key.(string))
 	}
 
-	var resp ApplicationAgentCredentialResponse
-	err := clientCtx.GetClient().Post(ctx, "/application-agent-credentials", req, &resp)
+	resp, err := postAppAgentCredentialWithRetry(ctx, clientCtx.GetClient(), &req)
+	if IsNotFoundError(err) {
+		// Retries are exhausted and the referenced application agent is still not
+		// visible. Surface a hard error: the not-found warning HasFailed would emit
+		// leaves Terraform with an inconsistent (created-but-unset) result.
+		return append(d, diag.Errorf(
+			"application agent %q was not found after %d attempts; it may not have "+
+				"finished propagating on the backend",
+			req.ApplicationAgentID, credCreateMaxRetries+1)...)
+	}
 	if HasFailed(&d, err) {
 		return d
 	}

--- a/indykite/resource_application_agent_credential_test.go
+++ b/indykite/resource_application_agent_credential_test.go
@@ -261,8 +261,150 @@ var _ = Describe("Resource ApplicationAgentCredential", func() {
 			},
 		})
 	})
+
+	It("Retries create while the app agent is not yet propagated", func() {
+		// Keep the test fast: shorten the retry delay for the duration of this spec.
+		defer indykite.SetCredCreateRetryDelay(time.Millisecond)()
+
+		tfConfig := `resource "indykite_application_agent_credential" "development" {
+				app_agent_id = "` + appAgentID + `"
+				public_key_jwk = <<-EOT
+				{
+					"kty": "EC",
+					"use": "sig",
+					"crv": "P-256",
+					"kid": "xuyd5-9bT0L09mi810mycfREAxBG3KnpctlGQCYtCdM",
+					"x": "o7LnIMhCPXFV91sE5EKQh8QZ9U6csUqgSENaKt3T0I4",
+					"y": "o1Wwws1ZeoSwh_yN8_jeFOWHwK2n_6ow15SxIHyAnpE",
+					"alg": "ES256"
+				}
+				EOT
+				expire_time = "` + time.Now().Add(time.Hour).UTC().Format(time.RFC3339) + `"
+			}`
+
+		createTime := time.Now()
+		// The first two POSTs return 404 to mimic an app agent that has not
+		// propagated yet; the third succeeds.
+		const failUntilAttempt = 2
+		postAttempts := 0
+
+		mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/application-agent-credentials"):
+				postAttempts++
+				if postAttempts <= failUntilAttempt {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(map[string]string{"message": "application agent not found"})
+					return
+				}
+				resp := indykite.ApplicationAgentCredentialResponse{
+					ID:                 appAgentCredID,
+					CustomerID:         customerID,
+					AppSpaceID:         appSpaceID,
+					ApplicationID:      applicationID,
+					ApplicationAgentID: appAgentID,
+					Kid:                "EfUEiFnOzA5PCp8SSksp7iXv7cHRehCsIGo6NAQ9H7w",
+					CreateTime:         createTime,
+					CreateBy:           "creator-id",
+					AgentConfig: json.RawMessage(
+						`{"appAgentId":"` + appAgentID + `","endpoint":"https://example.com"}`),
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.Method == http.MethodGet:
+				resp := indykite.ApplicationAgentCredentialResponse{
+					ID:                 appAgentCredID,
+					CustomerID:         customerID,
+					AppSpaceID:         appSpaceID,
+					ApplicationID:      applicationID,
+					ApplicationAgentID: appAgentID,
+					Kid:                "EfUEiFnOzA5PCp8SSksp7iXv7cHRehCsIGo6NAQ9H7w",
+					CreateTime:         createTime,
+					CreateBy:           "creator-id",
+				}
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(resp)
+
+			case r.Method == http.MethodDelete:
+				w.WriteHeader(http.StatusNoContent)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+
+		cfgFunc := provider.ConfigureContextFunc
+		provider.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (any, diag.Diagnostics) {
+			client := indykite.NewTestRestClient(mockServer.URL+"/configs/v1", mockServer.Client())
+			ctx = indykite.WithClient(ctx, client)
+			return cfgFunc(ctx, data)
+		}
+
+		resource.Test(GinkgoT(), resource.TestCase{
+			Providers: map[string]*schema.Provider{
+				"indykite": provider,
+			},
+			Steps: []resource.TestStep{
+				{
+					Config: tfConfig,
+					Check: resource.ComposeTestCheckFunc(
+						testAppAgentCredResourceDataExists(resourceName, appAgentCredID, "jwk"),
+						func(*terraform.State) error {
+							if postAttempts != failUntilAttempt+1 {
+								return fmt.Errorf("expected %d POST attempts, got %d",
+									failUntilAttempt+1, postAttempts)
+							}
+							return nil
+						},
+					),
+				},
+			},
+		})
+	})
+
+	It("Fails create after exhausting propagation retries", func() {
+		defer indykite.SetCredCreateRetryDelay(time.Millisecond)()
+
+		tfConfig := `resource "indykite_application_agent_credential" "development" {
+				app_agent_id = "` + appAgentID + `"
+			}`
+
+		postAttempts := 0
+		mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				postAttempts++
+			}
+			// Always report the app agent as not found.
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "application agent not found"})
+		}))
+
+		cfgFunc := provider.ConfigureContextFunc
+		provider.ConfigureContextFunc = func(ctx context.Context, data *schema.ResourceData) (any, diag.Diagnostics) {
+			client := indykite.NewTestRestClient(mockServer.URL+"/configs/v1", mockServer.Client())
+			ctx = indykite.WithClient(ctx, client)
+			return cfgFunc(ctx, data)
+		}
+
+		resource.Test(GinkgoT(), resource.TestCase{
+			Providers: map[string]*schema.Provider{
+				"indykite": provider,
+			},
+			Steps: []resource.TestStep{
+				{
+					Config:      tfConfig,
+					ExpectError: regexp.MustCompile(`was not found after \d+ attempts`),
+				},
+			},
+		})
+
+		// Initial attempt plus the bounded retries.
+		Expect(postAttempts).To(Equal(indykite.CredCreateMaxRetries() + 1))
+	})
 })
 
+//nolint:unparam // Test helper function designed to be reusable
 func testAppAgentCredResourceDataExists(
 	n string,
 	expectedID string,

--- a/indykite/resource_service_account_credential.go
+++ b/indykite/resource_service_account_credential.go
@@ -55,11 +55,12 @@ func resourceServiceAccountCredential() *schema.Resource {
 				Description:      "Optional human readable name of the credential.",
 			},
 			expireTimeKey: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IsRFC3339Time,
-				Description:  "Optional date-time when credentials are going to expire in RFC3339 format.",
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateFunc:     validation.IsRFC3339Time,
+				DiffSuppressFunc: ExpireTimeDiffSuppress,
+				Description:      "Optional date-time when credentials are going to expire in RFC3339 format.",
 			},
 			kidKey: {
 				Type:        schema.TypeString,

--- a/indykite/utilities.go
+++ b/indykite/utilities.go
@@ -158,6 +158,21 @@ func DisplayNameCredentialDiffSuppress(k, old, newVal string, d *schema.Resource
 	return false
 }
 
+// ExpireTimeDiffSuppress suppresses Terraform changes when the old and new expire_time values
+// represent the same instant in different timezone representations. The API normalizes the
+// timestamp to UTC, so a config value like "2026-12-31T12:34:56-01:00" comes back as
+// "2026-12-31T13:34:56Z" and would otherwise force resource replacement.
+func ExpireTimeDiffSuppress(_, old, newVal string, _ *schema.ResourceData) bool {
+	// RFC3339Nano parses both plain-second and fractional-second timestamps. (Plain
+	// time.RFC3339 also accepts fractional seconds on parse, but Nano makes intent explicit.)
+	o, err1 := time.Parse(time.RFC3339Nano, old)
+	n, err2 := time.Parse(time.RFC3339Nano, newVal)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return o.Equal(n)
+}
+
 // SuppressYamlDiff verify that 2 YAML strings are the same in value and suppress Terraform changes.
 func SuppressYamlDiff(_, old, newVal string, _ *schema.ResourceData) bool {
 	var oldMap, newMap map[string]any

--- a/indykite/utilities_test.go
+++ b/indykite/utilities_test.go
@@ -70,6 +70,29 @@ var _ = Describe("Utilities", func() {
 		Entry("Display name is same as name", "display_name", "abc", "abc", "", BeTrue()),
 		Entry("Display name is different than name", "display_name", "abc", "jkl", "", BeFalse()),
 	)
+
+	DescribeTable("ExpireTimeDiffSuppress",
+		func(old, newVal string, expected OmegaMatcher) {
+			Expect(indykite.ExpireTimeDiffSuppress("expire_time", old, newVal, nil)).To(expected)
+		},
+		// Same instant expressed with a different timezone offset must be suppressed,
+		// because the API normalizes the value to UTC (this is the drift being fixed).
+		Entry("Same instant, UTC vs offset",
+			"2026-12-31T13:34:56Z", "2026-12-31T12:34:56-01:00", BeTrue()),
+		Entry("Same instant, extra nanoseconds",
+			"2026-12-31T13:34:56Z", "2026-12-31T13:34:56.000Z", BeTrue()),
+		Entry("Identical values", "2026-12-31T13:34:56Z", "2026-12-31T13:34:56Z", BeTrue()),
+		// Genuinely different instants must NOT be suppressed so ForceNew still triggers.
+		Entry("Different instant, one hour later",
+			"2026-12-31T13:34:56Z", "2026-12-31T14:34:56Z", BeFalse()),
+		Entry("Different instant, different day",
+			"2026-12-31T13:34:56Z", "2026-11-30T12:34:56-01:00", BeFalse()),
+		// Empty (adding or removing an expiry) does not parse and must NOT be suppressed.
+		Entry("Adding expiry from empty", "", "2026-12-31T12:34:56-01:00", BeFalse()),
+		Entry("Removing expiry", "2026-12-31T13:34:56Z", "", BeFalse()),
+		// Unparseable value falls back to showing the diff.
+		Entry("Unparseable new value", "2026-12-31T13:34:56Z", "not-a-time", BeFalse()),
+	)
 })
 
 var _ = Describe("HasFailed", func() {


### PR DESCRIPTION
implement [ENG-8960]

- wait until app agent is available before creating credentials
- fix 2 different time formats


[ENG-8960]: https://indykite.atlassian.net/browse/ENG-8960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ