### PR TITLE
fix: cleanup on failure

### DIFF
--- a/tests/test_integration.sh
+++ b/tests/test_integration.sh
@@ -16,16 +16,32 @@ if ! command -v "${TERRAFORM_BIN}" >/dev/null 2>&1; then
     exit 1
 fi
 
+APPLIED=0
+
 cleanup() {
-    if [[ -f "${TESTS_PROVIDER_DIR}/test.tf.bak" ]]; then
-        mv -f "${TESTS_PROVIDER_DIR}/test.tf.bak" "${TESTS_PROVIDER_DIR}/test.tf"
+    local rc=$?
+    trap - EXIT
+    if [[ "${APPLIED}" -eq 1 ]]; then
+        if [[ -f "${TESTS_PROVIDER_DIR}/test.tf.bak" ]]; then
+            mv -f "${TESTS_PROVIDER_DIR}/test.tf.bak" "${TESTS_PROVIDER_DIR}/test.tf" ||
+                echo ">>> Cleanup: failed to restore test.tf from backup" >&2
+        fi
+        echo ">>> Cleanup: running terraform destroy (main rc=${rc})"
+        if ! "${TERRAFORM_BIN}" -chdir="${TESTS_PROVIDER_DIR}" destroy -input=false -auto-approve; then
+            echo ">>> Cleanup: terraform destroy failed" >&2
+            [[ "${rc}" -eq 0 ]] && rc=1
+        fi
+        # Non-fatal so a filesystem error cannot overwrite the real exit code.
+        rm -f "${TESTS_PROVIDER_DIR}/terraform.tfstate" "${TESTS_PROVIDER_DIR}/terraform.tfstate.backup" ||
+            echo ">>> Cleanup: failed to remove local tfstate files" >&2
     fi
-    rm -f "${TESTS_PROVIDER_DIR}/terraform.tfstate" "${TESTS_PROVIDER_DIR}/terraform.tfstate.backup"
+    exit "${rc}"
 }
 
 trap cleanup EXIT
 
 "${TERRAFORM_BIN}" -chdir="${TESTS_PROVIDER_DIR}" plan
+APPLIED=1
 "${TERRAFORM_BIN}" -chdir="${TESTS_PROVIDER_DIR}" apply -input=false -auto-approve
 
 cd "${TESTS_TERRAFORM_DIR}"
@@ -39,4 +55,4 @@ sed -i \
     -e 's/route_display_name\(\s*=\s*"\)/route_display_name\1Updated - /g' \
     test.tf
 "${TERRAFORM_BIN}" apply -input=false -auto-approve
-"${TERRAFORM_BIN}" destroy -input=false -auto-approve
+# terraform destroy runs automatically via the EXIT trap above


### PR DESCRIPTION
Relates: ENG-9185

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/indykite/.github/blob/master/commit-message.md)
- [ ] is breaking change

## Description of change

Fixing cleanup performed by `tf destroy` for the integration tests. If anything goes wrong between the `tf apply` (we have two of them) and the `tf destroy`, it will not be executed, hence we may accumulate leftovers in the platform. That's why I moved the `tf destroy` execution in the EXIT trap similar to [startscript.sh](https://github.com/indykite/terraform-provider-indykite/blob/master/docker/infra/full/startscript.sh)
