### PR TITLE
ci: resolve goreleaser deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
         goarch: '386'
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-  - format: zip # TODO: deprecated in favour of archives.format_overrides.formats [ENG-8895]
+  - formats: ["zip"]
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/indykite/.github/blob/master/commit-message.md)
- [ ] is breaking change

## Description of change

[ENG-8895]: Resolve `archives.formats` deprecation warning in GoReleaser. ref: https://goreleaser.com/customization/package/archives/

**Output**

```
goreleaser release --snapshot --clean
  • starting release
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • using tags                                     previous=v0.38.0 current=v0.39.0
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=0.39.0-SNAPSHOT-c10ed36
  • running before hooks
    • running                                        hook=go mod tidy
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=freebsd_arm64_v8.0
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=freebsd_arm_6
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=freebsd_amd64_v1
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=linux_amd64_v1
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=windows_386_sse2
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=windows_amd64_v1
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=freebsd_386_sse2
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=windows_arm64_v8.0
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=linux_386_sse2
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=linux_arm_6
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=linux_arm64_v8.0
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=darwin_amd64_v1
    • building                                       paths=. binaries={{ .ProjectName }}_v{{ .Version }} target=darwin_arm64_v8.0
  • archives
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_windows_arm64.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_windows_amd64.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_linux_arm64.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_freebsd_amd64.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_linux_386.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_freebsd_arm.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_linux_amd64.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_freebsd_386.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_linux_arm.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_freebsd_arm64.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_darwin_amd64.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_darwin_arm64.zip
    • archiving                                      name=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_windows_386.zip
  • calculating checksums
  • signing artifacts
    • signing                                        cmd=/usr/local/bin/gpg artifact=terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_SHA256SUMS signature=dist/terraform-provider-indykite_0.39.0-SNAPSHOT-c10ed36_SHA256SUMS.sig
  • writing artifacts metadata
  • release succeeded after 10s
  • thanks for using GoReleaser!
***

[ENG-8895]: https://indykite.atlassian.net/browse/ENG-8895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ